### PR TITLE
Dependencies fix 

### DIFF
--- a/LuttuLibrary/build.gradle
+++ b/LuttuLibrary/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 10
         targetSdkVersion 23
     }
     buildTypes {

--- a/LuttuLibrary/build.gradle
+++ b/LuttuLibrary/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 23
     }
     buildTypes {

--- a/OpenVehicleApp/build.gradle
+++ b/OpenVehicleApp/build.gradle
@@ -3,10 +3,9 @@ apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
     defaultConfig {
         applicationId "com.openvehicles.OVMS"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 23
     }
     buildTypes {
@@ -32,13 +31,13 @@ repositories {
 }
 
 dependencies {
-    compile project(':LuttuLibrary')
-    compile files('libs/gson-2.3.1.jar')
-    //compile 'com.github.PhilJay:MPAndroidChart:v2.2.2'
-    compile files('libs/mpandroidchart-2.2.3.jar')
-    compile 'com.androidmapsextensions:android-maps-extensions:2.2.0'
-    compile 'com.android.support:support-v4:23.0.+'
-    compile 'com.android.support:appcompat-v7:23.0.+'
-    compile 'com.google.android.gms:play-services-maps:8.1.0'
-    compile 'com.google.android.gms:play-services-gcm:8.1.0'
+    implementation project(':LuttuLibrary')
+    implementation files('libs/gson-2.3.1.jar')
+    //implementation 'com.github.PhilJay:MPAndroidChart:v2.2.2'
+    implementation files('libs/mpandroidchart-2.2.3.jar')
+    implementation 'com.androidmapsextensions:android-maps-extensions:2.2.0'
+    implementation 'com.android.support:support-v4:23.4.0'
+    implementation 'com.android.support:appcompat-v7:23.4.0'
+    implementation 'com.google.android.gms:play-services-maps:8.1.0'
+    implementation 'com.google.android.gms:play-services-gcm:8.1.0'
 }

--- a/OpenVehicleApp/build.gradle
+++ b/OpenVehicleApp/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 23
     defaultConfig {
         applicationId "com.openvehicles.OVMS"
-        minSdkVersion 14
+        minSdkVersion 10
         targetSdkVersion 23
     }
     buildTypes {


### PR DESCRIPTION
- Update dependencies to fix #63 
- Rename compile to implementation as recomended by android studiio https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle
- Remove `buildToolsVersion` since this is no longer used. Build tools version is autodetected from target sdk 