### PR TITLE
'mile' unit abbreviation

### DIFF
--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
@@ -371,7 +371,7 @@ public class CarData implements Serializable {
 				car_soc_raw = Float.parseFloat(dataParts[0]);
 				car_soc = String.format("%.1f%%", car_soc_raw);
 				car_distance_units_raw = dataParts[1];
-				car_distance_units = (car_distance_units_raw.startsWith("M")) ? "m" : "km";
+				car_distance_units = (car_distance_units_raw.startsWith("M")) ? "mi" : "km";
 				car_speed_units = (car_distance_units_raw.startsWith("M"))
 						? mContext.getText(R.string.mph).toString()
 						: mContext.getText(R.string.kph).toString();


### PR DESCRIPTION
Minor change to use the unit abbreviation 'mi' instead of 'm' to denote miles. 'mi' is the standard abbreviation for miles and avoid any confusion with metres!

![screenshot_20180812-153807](https://user-images.githubusercontent.com/758844/44005042-9ba5450a-9e64-11e8-8ecb-8a711fed9992.png)
