### PR TITLE
Display charging power

### DIFF
--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
@@ -382,8 +382,8 @@ public class CarData implements Serializable {
 				car_charge_current = String.format("%.1f%s", car_charge_current_raw, "A");
 //				calculate real-time battery charge power level (kW) if not returned by the car
 				if (car_charge_current_raw >0 && car_charge_power_kw_raw<=0)
-					car_charge_power_kw = (car_charge_linevoltage_raw * car_charge_current_raw)/1000;
-				car_charge_power_kw = String.format("%.1f%s", car_charge_power_kw, "kW");
+					car_charge_power_kw_raw = (car_battery_voltage * car_charge_current_raw)/1000;
+				car_charge_power_kw = String.format("%.1f%s", car_charge_power_kw_raw, "kW");
 				car_charge_voltagecurrent = String.format("%.1f%s %.1f%s",
 						car_charge_linevoltage_raw, "V",
 						car_charge_current_raw, "A");
@@ -746,7 +746,7 @@ public class CarData implements Serializable {
 			b.putFloat("car_charge_currentlimit", car_charge_currentlimit_raw);
 			b.putInt("car_charge_duration", car_charge_duration_raw);
 			b.putInt("car_charge_plugtype", car_charge_plugtype);
-			b.putDouble("car_charge_power_kw", car_charge_power_kw);
+			b.putDouble("car_charge_power_kw_raw", car_charge_power_kw_raw);
 			b.putFloat("car_charge_kwhconsumed", car_charge_kwhconsumed / 10f);
 			b.putBoolean("car_charge_timer", car_charge_timer);
 

--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
@@ -92,7 +92,7 @@ public class CarData implements Serializable {
 	public String car_soc = "";
 	public String car_charge_linevoltage = "";
 	public String car_charge_current = "";
-	public String car_charge_power_real_kwh;
+	public String car_charge_power_kw;
 	public String car_charge_voltagecurrent = "";
 	public String car_charge_currentlimit = "";
 	public String car_charge_mode = "";
@@ -186,7 +186,7 @@ public class CarData implements Serializable {
 	public int car_chargelimit_minsremaining_soc = -1;
 	public int car_max_idealrange_raw = 0;
 	public int car_charge_plugtype = 0;
-	public double car_charge_power_kw = 0;
+	public double car_charge_power_kw_raw = 0;
 	public double car_battery_voltage = 0;
 	public float car_soh = 0;
 
@@ -380,9 +380,10 @@ public class CarData implements Serializable {
 				car_charge_linevoltage = String.format("%.1f%s", car_charge_linevoltage_raw, "V");
 				car_charge_current_raw = Float.parseFloat(dataParts[3]);
 				car_charge_current = String.format("%.1f%s", car_charge_current_raw, "A");
-				if (car_charge_current_raw >0 && car_charge_power_kw<=0)
+//				calculate real-time battery charge power level (kW) if not returned by the car
+				if (car_charge_current_raw >0 && car_charge_power_kw_raw<=0)
 					car_charge_power_kw = (car_charge_linevoltage_raw * car_charge_current_raw)/1000;
-				car_charge_power_real_kwh = String.format("%.1f%s", car_charge_power_kw, "kW");
+				car_charge_power_kw = String.format("%.1f%s", car_charge_power_kw, "kW");
 				car_charge_voltagecurrent = String.format("%.1f%s %.1f%s",
 						car_charge_linevoltage_raw, "V",
 						car_charge_current_raw, "A");
@@ -448,7 +449,7 @@ public class CarData implements Serializable {
 			}
 			if (dataParts.length >= 33) {
 				car_charge_plugtype = Integer.parseInt(dataParts[30]);
-				car_charge_power_kw = Double.parseDouble(dataParts[31]);
+				car_charge_power_kw_raw = Double.parseDouble(dataParts[31]);
 				car_battery_voltage = Double.parseDouble(dataParts[32]);
 			}
 			if (dataParts.length >= 34) {

--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/entities/CarData.java
@@ -92,6 +92,7 @@ public class CarData implements Serializable {
 	public String car_soc = "";
 	public String car_charge_linevoltage = "";
 	public String car_charge_current = "";
+	public String car_charge_power_real_kwh;
 	public String car_charge_voltagecurrent = "";
 	public String car_charge_currentlimit = "";
 	public String car_charge_mode = "";
@@ -379,6 +380,9 @@ public class CarData implements Serializable {
 				car_charge_linevoltage = String.format("%.1f%s", car_charge_linevoltage_raw, "V");
 				car_charge_current_raw = Float.parseFloat(dataParts[3]);
 				car_charge_current = String.format("%.1f%s", car_charge_current_raw, "A");
+				if (car_charge_current_raw >0 && car_charge_power_kw<=0)
+					car_charge_power_kw = (car_charge_linevoltage_raw * car_charge_current_raw)/1000;
+				car_charge_power_real_kwh = String.format("%.1f%s", car_charge_power_kw, "kW");
 				car_charge_voltagecurrent = String.format("%.1f%s %.1f%s",
 						car_charge_linevoltage_raw, "V",
 						car_charge_current_raw, "A");

--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
@@ -559,6 +559,8 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 		TextView tvl = (TextView) findViewById(R.id.tabInfoTextChargeStatusLeft);
 		TextView tvr = (TextView) findViewById(R.id.tabInfoTextChargeStatusRight);
 		TextView tvf = (TextView) findViewById(R.id.tabInfoTextChargeStatus);
+		TextView tvp = (TextView) findViewById(R.id.tabInfoTextChargeStatusPower);
+
 
 		if ((!pCarData.car_chargeport_open)
 				|| (pCarData.car_charge_substate_i_raw == 0x07)) {
@@ -572,6 +574,7 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 			tvl.setVisibility(View.INVISIBLE);
 			tvr.setVisibility(View.INVISIBLE);
 			tvf.setVisibility(View.INVISIBLE);
+			tvp.setVisibility(View.INVISIBLE);
 
 		} else {
 			// Car is plugged in
@@ -608,6 +611,8 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 							pCarData.car_charge_linevoltage,
 							pCarData.car_charge_current));
 					tvf.setVisibility(View.VISIBLE);
+					tvp.setText(String.format(pCarData.car_charge_power_real_kwh));
+					tvp.setVisibility(View.VISIBLE);
 				}
 
 				coiv.setVisibility(View.VISIBLE);

--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
@@ -561,7 +561,7 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 		TextView tvf = (TextView) findViewById(R.id.tabInfoTextChargeStatus);
 		TextView tvp = (TextView) findViewById(R.id.tabInfoTextChargeStatusPower);
 
-		tvp.setText(String.format(pCarData.car_charge_power_real_kwh));
+		tvp.setText(String.format(pCarData.car_charge_power_kw));
 		tvp.setVisibility(View.VISIBLE);
 
 		if ((!pCarData.car_chargeport_open)

--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/InfoFragment.java
@@ -561,6 +561,8 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 		TextView tvf = (TextView) findViewById(R.id.tabInfoTextChargeStatus);
 		TextView tvp = (TextView) findViewById(R.id.tabInfoTextChargeStatusPower);
 
+		tvp.setText(String.format(pCarData.car_charge_power_real_kwh));
+		tvp.setVisibility(View.VISIBLE);
 
 		if ((!pCarData.car_chargeport_open)
 				|| (pCarData.car_charge_substate_i_raw == 0x07)) {
@@ -611,8 +613,7 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 							pCarData.car_charge_linevoltage,
 							pCarData.car_charge_current));
 					tvf.setVisibility(View.VISIBLE);
-					tvp.setText(String.format(pCarData.car_charge_power_real_kwh));
-					tvp.setVisibility(View.VISIBLE);
+
 				}
 
 				coiv.setVisibility(View.VISIBLE);
@@ -628,6 +629,7 @@ public class InfoFragment extends BaseFragment implements OnClickListener,
 				bar.setVisibility(View.VISIBLE);
 				tvl.setVisibility(View.VISIBLE);
 				tvr.setVisibility(View.VISIBLE);
+				tvp.setVisibility(View.VISIBLE);
 
 				switch (pCarData.car_charge_state_i_raw) {
 					case 0x04: // Done

--- a/OpenVehicleApp/src/main/res/layout/fragment_info.xml
+++ b/OpenVehicleApp/src/main/res/layout/fragment_info.xml
@@ -168,6 +168,17 @@
             android:textSize="24px"
             android:textStyle="bold" />
 
+        <TextView
+            android:id="@+id/tabInfoTextChargeStatusPower"
+            style="@style/TabCarTextBox"
+            android:layout_height="46px"
+            android:layout_x="265px"
+            android:layout_y="284px"
+            android:text="@string/DefaultChargingPower"
+            android:textSize="25px"
+			android:textStyle="bold"
+            android:gravity="center_vertical|left"/>
+
 		<TextView
 			android:id="@+id/tabInfoTextChargeStatusLeft"
 			style="@style/TabCarTextBox"

--- a/OpenVehicleApp/src/main/res/values/strings.xml
+++ b/OpenVehicleApp/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="SignalStrength">Signal Strength</string>
     <string name="ChargerPlug">Charger Plug</string>
     <string name="DefaultCharging">70A/220V</string>
+    <string name="DefaultChargingPower">15.4kW</string>
     <string name="DefaultSlidetoCharge">SLIDE TO\nCHARGE</string>
     <string name="DefaultMode">STANDARD</string>
     <string name="ChargingOverlay">Charging</string>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.google.gms:google-services:1.4.0-beta3'
     }
 }


### PR DESCRIPTION
- Display charging power (kW) when EV is charging
- Uses `car_charge_power_kw` if available, if not (as is the case with Nissan leaf), power is calculated by multiplying current and voltage.

A display of charging power help avoid the confusion I experienced due to confusing DC current with AC current https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/issues/149. Most EV drivers are most familiar with charging power in kW rather than battery voltage/ DC current. 

Location and font size open to discussion? 

![screenshot_20180813-133924](https://user-images.githubusercontent.com/758844/44032458-0d67d532-9eff-11e8-9234-53a02f20b3de.png)

 