### PR TITLE
Charging mode display 

### DIFF
--- a/OpenVehicleApp/src/main/res/layout/fragment_info.xml
+++ b/OpenVehicleApp/src/main/res/layout/fragment_info.xml
@@ -78,11 +78,11 @@
 			android:id="@+id/tabInfoTextChargeMode"
 			android:layout_width="340px"
 			android:layout_height="40px"
-			android:layout_x="89px"
-			android:layout_y="510px"
-			android:gravity="bottom|right"
-            android:textSize="24px"
-            android:textColor="#fff07d00"
+			android:layout_x="105px"
+			android:layout_y="410px"
+			android:gravity="bottom|center"
+            android:textSize="22px"
+            android:textColor="#ffffffff"
             android:textStyle="bold" />
 
         <ImageView


### PR DESCRIPTION
- Adjust location and formatting of charging mode to improve readability
- I found the orange text difficult to read, especially when the battery was at low SOC

**After:**
![after](https://user-images.githubusercontent.com/758844/44009864-a1b819d0-9ea6-11e8-905d-858c7ae20ef7.png)

**Before:**
![before](https://user-images.githubusercontent.com/758844/44009868-a967a218-9ea6-11e8-82fa-68c8bf671123.png)


