### PR TITLE
fix service label always shown

### DIFF
--- a/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/settings/CarInfoFragment.java
+++ b/OpenVehicleApp/src/main/java/com/openvehicles/OVMS/ui/settings/CarInfoFragment.java
@@ -83,9 +83,12 @@ public class CarInfoFragment extends BaseFragment {
 			serviceInfo += String.format("%d days", mCarData.car_servicedays);
 		}
 		TextView serviceTextView = (TextView) rootView.findViewById(R.id.txt_service_info);
+		TextView serviceView = (TextView) rootView.findViewById(R.id.service_info);
 		if (serviceInfo.equals("")) {
+			serviceView.setVisibility(View.GONE);
 			serviceTextView.setVisibility(View.GONE);
 		} else {
+			serviceView.setVisibility(View.VISIBLE);
 			serviceTextView.setVisibility(View.VISIBLE);
 			serviceTextView.setText(serviceInfo);
 		}

--- a/OpenVehicleApp/src/main/res/layout/fragment_car_info.xml
+++ b/OpenVehicleApp/src/main/res/layout/fragment_car_info.xml
@@ -178,6 +178,7 @@
 		android:text="@string/Charged" />
 
 	<TextView
+		android:id="@+id/service_info"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:layout_alignBaseline="@id/txt_service_info"


### PR DESCRIPTION
not sure if this is the most elegant way to do it, but the label "Service" needs to disappear as well as the text field if the car doesn't supply the service data.