### PR TITLE
fix push notifications

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/api/ApiService.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/api/ApiService.kt
@@ -314,7 +314,7 @@ class ApiService : Service(), ApiTask.ApiTaskListener, ApiObserver {
         try {
             if (apiTask != null) {
                 Log.v(TAG, "closeConnection: shutting down TCP connection")
-                apiTask!!.cancel(true)
+                //apiTask!!.cancel(true)
                 apiTask = null
                 notifyLoggedIn(this, false)
                 sendApiEvent("UpdateStatus")
@@ -483,8 +483,18 @@ class ApiService : Service(), ApiTask.ApiTaskListener, ApiObserver {
     }
 
     override fun onPushNotification(msgClass: Char, msgText: String?) {
-        // This callback only receives MP push notifications for the currently selected vehicle.
-        // See MyFirebaseMessagingService for system notification broadcasting.
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        createNotificationChannel()
+        // Create the notification
+        val notificationBuilder = NotificationCompat.Builder(this, "your_channel_id")
+            .setSmallIcon(R.drawable.ic_service)
+            .setContentTitle("OVMS")
+            .setContentText(msgText ?: msgText)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+
+        // Show the notification
+        notificationManager.notify(1, notificationBuilder.build())
     }
 
     // ApiObserver interface:


### PR DESCRIPTION
1. The apiTask is canceled in the `closeConnection()` method, which stops the doInBackground method from syncing with the server. I have uncommented the line, and now it listens continuously to the server.

2. The `handleMessage` method delegated the push notifications to the callback method `onPushNotification`, but the method body is empty. I added local push notifications, and now new notifications appear (tested on Android 14). In the future, it would be better to use Firebase instead.
