### PR TITLE
Add TLS connections to OVMS Servers

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
@@ -30,6 +30,10 @@ class CarData : Serializable {
     @JvmField
     var sel_server = "" // ServerNameOrIP
     @JvmField
+    var sel_tls = false // Use TLS for server connection
+    @JvmField
+    var sel_tls_trust_all = false // Trust all certificates for TLS
+    @JvmField
     var sel_gcm_senderid = "" // GCM sender ID (empty = default OVMS ID)
     @JvmField
     var sel_vehicleid = "" // VehicleID

--- a/app/src/main/java/com/openvehicles/OVMS/ui/settings/CarEditorFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui/settings/CarEditorFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.BaseAdapter
+import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.Gallery
 import android.widget.ImageView
@@ -186,6 +187,8 @@ class CarEditorFragment : BaseFragment() {
             carData!!.sel_server =
                 getValidValue(rootView, R.id.txt_server_address, StringValidator())
             carData!!.sel_gcm_senderid = getValue(rootView, R.id.txt_gcm_senderid)
+            carData!!.sel_tls = (rootView.findViewById<View>(R.id.chk_tls_enabled) as CheckBox).isChecked
+            carData!!.sel_tls_trust_all = (rootView.findViewById<View>(R.id.chk_tls_trust_all) as CheckBox).isChecked
             carData!!.sel_vehicle_image = availableColors[galleryCar!!.selectedItemPosition]
         } catch (e: ValidationException) {
             Log.e("Validation", e.message, e)
@@ -221,6 +224,16 @@ class CarEditorFragment : BaseFragment() {
             }
             Log.d(TAG, "load: server=" + carData!!.sel_server + " → position=" + position)
             setSelectedServer(position, false)
+
+            // set TLS options:
+            val chkTlsEnabled = requireView().findViewById<View>(R.id.chk_tls_enabled) as CheckBox
+            val chkTlsTrustAll = requireView().findViewById<View>(R.id.chk_tls_trust_all) as CheckBox
+            chkTlsEnabled.isChecked = carData!!.sel_tls
+            chkTlsTrustAll.isChecked = carData!!.sel_tls_trust_all
+            chkTlsTrustAll.isEnabled = carData!!.sel_tls
+            chkTlsEnabled.setOnClickListener {
+                chkTlsTrustAll.isEnabled = (it as CheckBox).isChecked
+            }
 
             // set car image:
             var index = -1

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/CarEditorFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/CarEditorFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.BaseAdapter
+import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.Gallery
@@ -183,6 +184,8 @@ class CarEditorFragment : BaseFragment() {
             carData!!.sel_server =
                 getValidValue(rootView, R.id.txt_server_address, StringValidator())
             carData!!.sel_gcm_senderid = getValue(rootView, R.id.txt_gcm_senderid)
+            carData!!.sel_tls = (rootView.findViewById<View>(R.id.chk_tls_enabled) as CheckBox).isChecked
+            carData!!.sel_tls_trust_all = (rootView.findViewById<View>(R.id.chk_tls_trust_all) as CheckBox).isChecked
             carData!!.sel_vehicle_image = availableColors[galleryCar!!.selectedItemPosition]
         } catch (e: ValidationException) {
             Log.e("Validation", e.message, e)
@@ -224,6 +227,16 @@ class CarEditorFragment : BaseFragment() {
             }
             Log.d(TAG, "load: server=" + carData!!.sel_server + " → position=" + position)
             setSelectedServer(position, false)
+
+            // set TLS options:
+            val chkTlsEnabled = requireView().findViewById<View>(R.id.chk_tls_enabled) as CheckBox
+            val chkTlsTrustAll = requireView().findViewById<View>(R.id.chk_tls_trust_all) as CheckBox
+            chkTlsEnabled.isChecked = carData!!.sel_tls
+            chkTlsTrustAll.isChecked = carData!!.sel_tls_trust_all
+            chkTlsTrustAll.isEnabled = carData!!.sel_tls
+            chkTlsEnabled.setOnClickListener {
+                chkTlsTrustAll.isEnabled = (it as CheckBox).isChecked
+            }
 
             // set car image:
             var index = -1

--- a/app/src/main/res/layout/fragment_careditor.xml
+++ b/app/src/main/res/layout/fragment_careditor.xml
@@ -81,6 +81,20 @@
 			android:hint="@string/GcmSenderID"
 			android:inputType="number" />
 
+		<CheckBox
+			android:id="@+id/chk_tls_enabled"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			android:text="@string/lb_tls_enabled" />
+
+		<CheckBox
+			android:id="@+id/chk_tls_trust_all"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="20dp"
+			android:text="@string/lb_tls_trust_all" />
+
 		<TextView
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_careditor_v2.xml
+++ b/app/src/main/res/layout/fragment_careditor_v2.xml
@@ -130,6 +130,19 @@
 
 		</com.google.android.material.textfield.TextInputLayout>
 
+		<com.google.android.material.switchmaterial.SwitchMaterial
+			android:id="@+id/chk_tls_enabled"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			android:text="@string/lb_tls_enabled" />
+
+		<com.google.android.material.switchmaterial.SwitchMaterial
+			android:id="@+id/chk_tls_trust_all"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="20dp"
+			android:text="@string/lb_tls_trust_all" />
 
 		<TextView
 			android:layout_width="wrap_content"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -116,6 +116,9 @@
         <item>Eigener Server</item>
     </string-array>
 
+    <string name="lb_tls_enabled">TLS für Serververbindung verwenden</string>
+    <string name="lb_tls_trust_all">TLS-Zertifikatsfehler ignorieren</string>
+
     <string name="lb_ft_digital_speedo">#%d: Digitaler Tacho</string>
     <string name="lb_ft_gps_stream">#%d: GPS Stream</string>
     <string name="lb_ft_minimum_soc">#%d: Minimaler SOC</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,6 +96,9 @@
     <string name="lb_reset_ovms_module">Restablecer módulo OVMS</string>
     <string name="lb_center_map">Centrar mapa</string>
 
+    <string name="lb_tls_enabled">Usar TLS para la conexión al servidor</string>
+    <string name="lb_tls_trust_all">Ignorar errores de certificado TLS</string>
+
     <string name="lb_ft_digital_speedo">#%d: Velocímetro digital</string>
     <string name="lb_ft_gps_stream">#%d: Flujo GPS</string>
     <string name="lb_ft_minimum_soc">#%d: SOC mínimo</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -109,6 +109,8 @@
     <string name="lb_reset_ovms_module">Käynnistä OVMS-moduuli uudelleen</string>
     <string name="lb_center_map">Keskitä kartta</string>
     <string name="lb_select_server">Valitse palvelin:</string>
+    <string name="lb_tls_enabled">Käytä TLS:ää palvelinyhteydessä</string>
+    <string name="lb_tls_trust_all">Ohita TLS-varmennevirheet</string>
     <string name="lb_ft_digital_speedo">#%d: Digitaalinen nopeusmittari</string>
     <string name="lb_ft_gps_stream">#%d: GPS-tietolähde</string>
     <string name="lb_ft_minimum_soc">#%d: Akun latauksen vähimmäismäärä</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -92,6 +92,8 @@
   <string name="lb_cellular_usage">Usage réseau mobile</string>
   <string name="lb_reset_ovms_module">Réinitialiser le module OVMS</string>
   <string name="lb_center_map">Centrer la carte</string>
+  <string name="lb_tls_enabled">Utiliser TLS pour la connexion au serveur</string>
+  <string name="lb_tls_trust_all">Ignorer les erreurs de certificat TLS</string>
   <string name="lb_ft_digital_speedo">#%d: Tachymètre</string>
   <string name="lb_ft_gps_stream">#%d: GPS temps réel</string>
   <string name="lb_ft_minimum_soc">#%d: Charge batterie minimum</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -92,6 +92,8 @@
   <string name="lb_cellular_usage">Mobiel Gebruik</string>
   <string name="lb_reset_ovms_module">Herstart OVMS Module</string>
   <string name="lb_center_map">Kaart Centreren</string>
+  <string name="lb_tls_enabled">Gebruik TLS voor de serververbinding</string>
+  <string name="lb_tls_trust_all">Negeer TLS-certificaatfouten</string>
   <string name="lb_ft_digital_speedo">#%d: Digitale Snelheidsmeter</string>
   <string name="lb_ft_gps_stream">#%d: GPS Stream</string>
   <string name="lb_ft_minimum_soc">#%d: Minimum SOC</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -78,6 +78,8 @@
     <string name="lb_cellular_usage">Mobil Bruk</string>
     <string name="lb_reset_ovms_module">Reset OVMS Modul</string>
     <string name="lb_center_map">Sentrer kart</string>
+    <string name="lb_tls_enabled">Bruk TLS for servertilkobling</string>
+    <string name="lb_tls_trust_all">Ignorer TLS-sertifikatfeil</string>
     <string name="lb_ft_digital_speedo">#%d: Digitalt Speedometer</string>
     <string name="lb_ft_gps_stream">#%d: GPS Strøm</string>
     <string name="lb_ft_minimum_soc">#%d: Minimum SOC</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,8 @@
         <item translatable="false"></item>
     </string-array>
 
+    <string name="lb_tls_enabled">Use TLS for server connection</string>
+    <string name="lb_tls_trust_all">Ignore TLS certificate errors</string>
 
     <string name="lb_ft_digital_speedo">#%d: Digital Speedo</string>
     <string name="lb_ft_gps_stream">#%d: GPS Stream</string>


### PR DESCRIPTION
Added option to connect via TLS to OVMS Server on port 6870.
I tested unencrypted, encrypted with valid cert, encrypted with invalid cert and tested the Ignore TLS certificate button.
Everything is working as expected.

The translation for the remaining languages coming from Google Translate, so it may not be perfect.

<img width="589" height="1312" alt="app_tls_checkboxes" src="https://github.com/user-attachments/assets/f6e2c0c2-68fd-4110-972d-c1bbe4232a25" />