### PR TITLE
Fix UI2 TLS Settings Crash

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/CarEditorFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/CarEditorFragment.kt
@@ -11,13 +11,13 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.BaseAdapter
-import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.Gallery
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.openvehicles.OVMS.R
 import com.openvehicles.OVMS.entities.CarData
@@ -184,8 +184,8 @@ class CarEditorFragment : BaseFragment() {
             carData!!.sel_server =
                 getValidValue(rootView, R.id.txt_server_address, StringValidator())
             carData!!.sel_gcm_senderid = getValue(rootView, R.id.txt_gcm_senderid)
-            carData!!.sel_tls = (rootView.findViewById<View>(R.id.chk_tls_enabled) as CheckBox).isChecked
-            carData!!.sel_tls_trust_all = (rootView.findViewById<View>(R.id.chk_tls_trust_all) as CheckBox).isChecked
+            carData!!.sel_tls = (rootView.findViewById<View>(R.id.chk_tls_enabled) as SwitchMaterial).isChecked
+            carData!!.sel_tls_trust_all = (rootView.findViewById<View>(R.id.chk_tls_trust_all) as SwitchMaterial).isChecked
             carData!!.sel_vehicle_image = availableColors[galleryCar!!.selectedItemPosition]
         } catch (e: ValidationException) {
             Log.e("Validation", e.message, e)
@@ -229,13 +229,13 @@ class CarEditorFragment : BaseFragment() {
             setSelectedServer(position, false)
 
             // set TLS options:
-            val chkTlsEnabled = requireView().findViewById<View>(R.id.chk_tls_enabled) as CheckBox
-            val chkTlsTrustAll = requireView().findViewById<View>(R.id.chk_tls_trust_all) as CheckBox
+            val chkTlsEnabled = requireView().findViewById<View>(R.id.chk_tls_enabled) as SwitchMaterial
+            val chkTlsTrustAll = requireView().findViewById<View>(R.id.chk_tls_trust_all) as SwitchMaterial
             chkTlsEnabled.isChecked = carData!!.sel_tls
             chkTlsTrustAll.isChecked = carData!!.sel_tls_trust_all
             chkTlsTrustAll.isEnabled = carData!!.sel_tls
             chkTlsEnabled.setOnClickListener {
-                chkTlsTrustAll.isEnabled = (it as CheckBox).isChecked
+                chkTlsTrustAll.isEnabled = (it as SwitchMaterial).isChecked
             }
 
             // set car image:


### PR DESCRIPTION
I mixed my local repo up. This fixes now the UI and UI2 for the TLS buttons.

This is without the NIU pictures, because its the same file.
<img width="1224" height="2700" alt="Screenshot_20250727-210941" src="https://github.com/user-attachments/assets/46c8c64a-77c7-4f5f-8c9d-ceb0c065bbcc" />
<img width="1224" height="2700" alt="Screenshot_20250727-211008" src="https://github.com/user-attachments/assets/03331e3c-bfee-4c86-a236-7392d6725e9a" />
