### PR TITLE
HomeFragment.kt reworked

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui2/components/hometabs/HomeTabsAdapter.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/components/hometabs/HomeTabsAdapter.kt
@@ -8,17 +8,20 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.openvehicles.OVMS.R
+import java.util.Collections
 
 
 class HomeTabsAdapter internal constructor(
     context: Context?,
-    var mData: List<HomeTab> = emptyList()
+    var mData: MutableList<HomeTab> = mutableListOf()
 ) : RecyclerView.Adapter<HomeTabsAdapter.ViewHolder>() {
     private val mInflater: LayoutInflater
     private var mClickListener: ItemClickListener? = null
+    private var mLongClickListener: ItemLongClickListener? = null
 
     init {
         mInflater = LayoutInflater.from(context)
+        setHasStableIds(true)
     }
 
     // inflates the row layout from xml when needed
@@ -34,24 +37,38 @@ class HomeTabsAdapter internal constructor(
         holder.tabSubTitle.visibility = if (action.tabDesc == null || action.tabDesc!!.isEmpty()) View.GONE else View.VISIBLE
         holder.tabSubTitle.text = action.tabDesc
         holder.clickListener = mClickListener
+        holder.longClickListener = mLongClickListener
+        // hideIndicator & drag handle optional external control via tags
+        holder.hideIndicator.visibility = if (action.tabDesc == "__HIDDEN__") View.VISIBLE else View.GONE
     }
 
     override fun getItemCount(): Int {
         return mData.size
     }
 
-    class ViewHolder internal constructor(itemView: View, var clickListener: ItemClickListener?) : RecyclerView.ViewHolder(itemView),
-        View.OnClickListener {
+    override fun getItemId(position: Int): Long {
+        return if (position in 0 until mData.size) mData[position].tabId.toLong() else RecyclerView.NO_ID
+    }
+
+    class ViewHolder internal constructor(itemView: View, var clickListener: ItemClickListener?, var longClickListener: ItemLongClickListener? = null) : RecyclerView.ViewHolder(itemView),
+        View.OnClickListener, View.OnLongClickListener {
         val tabName: TextView = itemView.findViewById(R.id.tabName)
         val tabSubTitle: TextView = itemView.findViewById(R.id.tabExtraInfo)
         val tabIcon: ImageView = itemView.findViewById(R.id.tabIcon)
+    val hideIndicator: ImageView = itemView.findViewById(R.id.hideIndicator)
 
         init {
             itemView.setOnClickListener(this)
+            itemView.setOnLongClickListener(this)
         }
 
         override fun onClick(view: View) {
             clickListener?.onItemClick(view, adapterPosition)
+        }
+
+        override fun onLongClick(v: View?): Boolean {
+            longClickListener?.onItemLongClick(adapterPosition)
+            return true
         }
     }
 
@@ -66,7 +83,29 @@ class HomeTabsAdapter internal constructor(
         mClickListener = itemClickListener
     }
 
+    fun setLongClickListener(itemLongClickListener: ItemLongClickListener?) {
+        mLongClickListener = itemLongClickListener
+    }
+
+    fun onRowMoved(fromPosition: Int, toPosition: Int) {
+        if (fromPosition == toPosition || fromPosition !in 0 until mData.size || toPosition !in 0 until mData.size) return
+        if (fromPosition < toPosition) {
+            for (i in fromPosition until toPosition) {
+                Collections.swap(mData, i, i + 1)
+            }
+        } else {
+            for (i in fromPosition downTo toPosition + 1) {
+                Collections.swap(mData, i, i - 1)
+            }
+        }
+        notifyItemMoved(fromPosition, toPosition)
+    }
+
     interface ItemClickListener {
         fun onItemClick(view: View?, position: Int)
+    }
+
+    interface ItemLongClickListener {
+        fun onItemLongClick(position: Int)
     }
 }

--- a/app/src/main/res/drawable/ic_tabs_menu.xml
+++ b/app/src/main/res/drawable/ic_tabs_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Using a generic 'tune/sort' style three-lines icon -->
+    <path
+        android:fillColor="#e8eaed"
+        android:pathData="M4,7h16c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1H4C3.45,5 3,5.45 3,6s0.45,1 1,1zM4,13h10c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1s0.45,1 1,1zM4,19h6c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1s0.45,1 1,1z" />
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -244,6 +244,7 @@
             android:background="?android:attr/listDivider" />
 
         <LinearLayout
+            android:id="@+id/footerContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="12sp"
@@ -272,10 +273,26 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:alpha="0.6"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/carModel"
-                app:layout_constraintStart_toStartOf="parent"
                 tools:text="VIN" />
+
+            <!-- Arrow hint placed directly below the upper text (car model + info) -->
+            <TextView
+                android:id="@+id/footerRestoreHint"
+                android:layout_width="35dp"
+                android:layout_height="35dp"
+                android:layout_marginTop="8dp"
+                android:layout_gravity="center_horizontal"
+                android:text="↕"
+                android:alpha="0.6"
+                android:visibility="gone"
+                android:textSize="30sp"
+                tools:visibility="visible"/>
+
+            <LinearLayout
+                android:id="@+id/footerAppBlock"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/home_tab_item.xml
+++ b/app/src/main/res/layout/home_tab_item.xml
@@ -16,7 +16,6 @@
         android:layout_gravity="center"
         android:layout_margin="12dp">
 
-
         <ImageView
             android:id="@+id/tabIcon"
             android:layout_width="28dp"
@@ -62,12 +61,25 @@
         </LinearLayout>
 
         <ImageView
+            android:id="@+id/hideIndicator"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginEnd="4dp"
+            android:contentDescription="hidden"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/linearLayout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/linearLayout"
+            app:srcCompat="@android:drawable/ic_menu_close_clear_cancel"
+            app:tint="@android:color/holo_red_light" />
+
+        <ImageView
             android:id="@+id/imageView4"
             android:layout_width="30dp"
             android:layout_height="30dp"
             android:layout_marginEnd="8dp"
             app:layout_constraintBottom_toBottomOf="@+id/linearLayout"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/hideIndicator"
             app:layout_constraintTop_toTopOf="@+id/linearLayout"
             app:srcCompat="@drawable/ic_tab_chevron"
             app:tint="?attr/colorOnSecondaryContainer" />

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -9,4 +9,10 @@
         android:icon="@drawable/ic_chat"
         android:title="@string/pushnotifications"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/home_tab_settings"
+        android:icon="@drawable/ic_tabs_menu"
+        android:title="@string/home_tab_settings"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,6 +68,11 @@
     <string name="App">App</string>
     <string name="CAC">Kapazität</string>
     <string name="Options">Optionen</string>
+    <string name="hint_long_press_hide">Lange auf einen Tab drücken zum Aus-/Einblenden</string>
+    <string name="action_hide_tab">Tab ausblenden</string>
+    <string name="action_unhide_tab">Tab einblenden</string>
+    <string name="action_reset_tabs">Tabs zurücksetzen</string>
+    <string name="drag_handle_description">Ziehen zum Sortieren</string>
 
     <string name="lb_wakeup_car">Auto aufwecken</string>
 
@@ -316,7 +321,8 @@
     <string name="logs_title">Diagnose-Logs</string>
     <string name="logs_btn_get">Abrufen</string>
     <string name="logs_btn_reset">Löschen</string>
-
+    <!-- Home tabs customization -->
+    <string name="more">ausgeblendete Tabs</string>
     <string name="logs_lb_alerts">Alarm</string>
     <string name="logs_lb_counter">Zähler</string>
     <string name="logs_lb_events">Logbuch</string>
@@ -362,6 +368,15 @@
     <string name="logs_msg_fetch_events">Logbuch abrufen&#8230;</string>
     <string name="logs_msg_fetch_counter">Zähler abrufen&#8230;</string>
     <string name="logs_msg_fetch_minmax">Min/Max abrufen&#8230;</string>
+
+    <!-- Home tab settings (added) -->
+    <string name="home_tab_settings">Tabs</string>
+    <string name="home_tab_manage_hidden">Ausgeblendete Tabs verwalten</string>
+    <string name="home_tab_none_hidden">Keine ausgeblendeten Tabs</string>
+    <string name="pref_show_footer">Footer anzeigen</string>
+    <string name="pref_show_footer_desc">Fahrzeug- und App-Info unten einblenden</string>
+    <string name="footer_hidden">Footer ausgeblendet</string>
+    <string name="footer_show">Einblenden</string>
 
     <string name="logs_msg_reset_faults">Fehler löschen&#8230;</string>
     <string name="logs_msg_reset_events">Logbuch löschen&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,22 @@
     <string name="logs_title">Diagnostic logs</string>
     <string name="logs_btn_get">Get logs</string>
     <string name="logs_btn_reset">Reset logs</string>
+    <!-- Home tabs customization -->
+    <string name="more">hided tabs</string>
+    <string name="hidden_items_count">%1$d hidden</string>
+    <string name="reset">Reset</string>
+    <string name="hint_long_press_hide">Long-press a tab to hide/show</string>
+    <string name="action_hide_tab">Hide tab</string>
+    <string name="action_unhide_tab">Show tab</string>
+    <string name="action_reset_tabs">Reset tabs</string>
+    <string name="drag_handle_description">Drag to reorder</string>
+    <string name="home_tab_settings">Tabs</string>
+    <string name="home_tab_manage_hidden">Manage hidden tabs</string>
+    <string name="home_tab_none_hidden">No hidden tabs</string>
+    <string name="pref_show_footer">Show footer info</string>
+    <string name="pref_show_footer_desc">Display car und app info block at bottom</string>
+    <string name="footer_hidden">Footer hidden</string>
+    <string name="footer_show">Show</string>
 
     <string name="logs_lb_alerts">Alerts</string>
     <string name="logs_lb_faults">Faults</string>


### PR DESCRIPTION
Added

- Drag & drop reordering for Home tabs
- Per‑vehicle storage for hidden tabs and footer expanded/collapsed state
- Tab visibility management dialog (hide/unhide) + toolbar menu entry with themed icon
- hint for long‑press tab actions (localized EN/DE)
- Collapsible footer section (app version, firmware, server, SOH)
- Restore handle (↕) to re‑expand footer; click forwarding on model / info / footer text.