### PR TITLE
Scheduled command widget: check for background command setting

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/appwidgets/ScheduledCommandWidgetConfigActivity.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/appwidgets/ScheduledCommandWidgetConfigActivity.kt
@@ -178,8 +178,37 @@ class ScheduledCommandWidgetConfigActivity : AppCompatActivity() {
             return
         }
         
+        // Check if background commands are enabled
+        val prefs = com.openvehicles.OVMS.utils.AppPrefs(this, "ovms")
+        val commandsEnabled = prefs.getData("option_commands_enabled", "0") == "1"
+        
+        if (!commandsEnabled) {
+            // Show warning and offer to enable
+            androidx.appcompat.app.AlertDialog.Builder(this)
+                .setTitle(R.string.background_commands_disabled_title)
+                .setMessage(R.string.background_commands_disabled_message)
+                .setPositiveButton(R.string.enable_and_save) { _, _ ->
+                    // Enable background commands
+                    prefs.saveData("option_commands_enabled", "1")
+                    // Continue with save
+                    performSave()
+                }
+                .setNegativeButton(R.string.save_anyway) { _, _ ->
+                    // Save without enabling
+                    performSave()
+                }
+                .setNeutralButton(android.R.string.cancel, null)
+                .show()
+            return
+        }
+        
+        performSave()
+    }
+    
+    private fun performSave() {
         val hour = timePicker.hour
         val minute = timePicker.minute
+        val selectedDays = getSelectedDays()
         
         try {
             // Save widget configuration

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -846,6 +846,10 @@
     <string name="please_select_command">Bitte wählen Sie einen Befehl</string>
     <string name="please_select_at_least_one_day">Bitte wählen Sie mindestens einen Tag</string>
     <string name="command_selected">Ausgewählt: %s</string>
+    <string name="background_commands_disabled_title">Hintergrundbefehle deaktiviert</string>
+    <string name="background_commands_disabled_message">Geplante Befehle benötigen aktivierte Hintergrund-Befehlsausführung in Einstellungen > Globale Optionen.\n\nMöchten Sie diese jetzt aktivieren?</string>
+    <string name="enable_and_save">Aktivieren &amp; Speichern</string>
+    <string name="save_anyway">Trotzdem speichern</string>
     <string name="day_mon">Mo</string>
     <string name="day_tue">Di</string>
     <string name="day_wed">Mi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -924,6 +924,10 @@
     <string name="please_select_at_least_one_day">Please select at least one day</string>
     <string name="command_selected">Selected: %s</string>
     <string name="widget_configured_successfully">Widget configured successfully</string>
+    <string name="background_commands_disabled_title">Background Commands Disabled</string>
+    <string name="background_commands_disabled_message">Scheduled commands require background command execution to be enabled in Settings > Global Options.\n\nWould you like to enable it now?</string>
+    <string name="enable_and_save">Enable &amp; Save</string>
+    <string name="save_anyway">Save Anyway</string>
     <string name="day_mon">Mo</string>
     <string name="day_tue">Tu</string>
     <string name="day_wed">We</string>


### PR DESCRIPTION
- Warn the user if background command execution is disabled when creating a scheduled command widget.
- Offer to enable the setting directly from the dialog.
- Added German translations for the new strings.

<img width="488" height="209" alt="widget_1" src="https://github.com/user-attachments/assets/4c95f7a9-8fdb-4815-8bd5-4a1b2c022df2" />


<img width="493" height="767" alt="widget_2" src="https://github.com/user-attachments/assets/dd483857-1557-40c2-ab6b-b8677eb6a542" />
