### PR TITLE
Stored commands: add delete button (icon)

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui/settings/StoredCommandFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui/settings/StoredCommandFragment.kt
@@ -104,11 +104,28 @@ class StoredCommandFragment : BaseFragment(), OnItemClickListener {
                 val cmd = adapter.getItem(position)
                 cmd?.let { pinCommand(it) }
             }
+            R.id.btn_delete.toLong() -> {
+                val cmd = adapter.getItem(position)
+                cmd?.let { confirmDeleteCommand(it) }
+            }
             else -> {
                 val cmd = adapter.getItem(position)
                 cmd?.let { showItemEditor(it) }
             }
         }
+    }
+
+    private fun confirmDeleteCommand(cmd: StoredCommand) {
+        val context = context ?: return
+        
+        AlertDialog.Builder(context)
+            .setTitle(R.string.Delete)
+            .setMessage(getString(R.string.confirm_delete_stored_command, cmd.title))
+            .setNegativeButton(R.string.Cancel, null)
+            .setPositiveButton(R.string.Delete) { _, _ ->
+                deleteCommand(cmd)
+            }
+            .show()
     }
 
     private fun showItemEditor(cmd: StoredCommand?) {
@@ -139,7 +156,8 @@ class StoredCommandFragment : BaseFragment(), OnItemClickListener {
             val dialog = AlertDialog.Builder(context)
                 .setMessage(R.string.stored_commands_edit)
                 .setView(view)
-                .setNegativeButton(R.string.Delete) { dialog12: DialogInterface?, which: Int ->
+                .setNegativeButton(R.string.Cancel, null)
+                .setNeutralButton(R.string.Delete) { dialog12: DialogInterface?, which: Int ->
                     val cmd12 = view.tag as StoredCommand
                     deleteCommand(cmd12)
                 }
@@ -252,6 +270,7 @@ class StoredCommandFragment : BaseFragment(), OnItemClickListener {
             }
             setOnClick(view!!, R.id.linearLayout1, position, this, null)
             setOnClick(view, R.id.btn_select, position, this, null)
+            setOnClick(view, R.id.btn_delete, position, this, null)
             val btnPin = setOnClick(view, R.id.btn_pin, position, this, null)
             if (requestCode == REQUEST_SELECT_SHORTCUT) {
                 val icon = ResourcesCompat.getDrawable(

--- a/app/src/main/res/layout/item_stored_command.xml
+++ b/app/src/main/res/layout/item_stored_command.xml
@@ -47,6 +47,19 @@
     </LinearLayout>
 
     <ImageButton
+        android:id="@+id/btn_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="5dp"
+        android:layout_weight="0"
+        android:background="@drawable/bg_img_button"
+        android:clickable="true"
+        android:contentDescription="@string/Delete"
+        android:focusable="true"
+        android:padding="16dp"
+        android:src="@drawable/ic_action_discard" />
+
+    <ImageButton
         android:id="@+id/btn_pin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -667,6 +667,7 @@
     <string name="stored_commands_add">Kommando zufügen</string>
     <string name="stored_commands_title">Gemerkte Kommandos</string>
     <string name="stored_commands_pin">Möchten Sie ein Icon für dieses Kommando auf Ihrem Startbildschirm erstellen?</string>
+    <string name="confirm_delete_stored_command">\"%s\" löschen?</string>
     <string name="lb_enter_title">Bezeichnung</string>
     <string name="lb_enter_command">Kommando</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -700,6 +700,7 @@
     <string name="stored_commands_add">Add Command</string>
     <string name="stored_commands_edit">Edit Command</string>
     <string name="stored_commands_pin">Do you want to add an icon for this command to your home screen?</string>
+    <string name="confirm_delete_stored_command">Delete \"%s\"?</string>
     <string name="lb_enter_title">Title/name</string>
     <string name="lb_enter_command">Command</string>
 


### PR DESCRIPTION
Added a dedicated delete button to each stored command item. This includes a confirmation dialog.
Edit stored command has been expanded to include "delete", "cancel", and "save".

<img width="378" height="110" alt="image" src="https://github.com/user-attachments/assets/57b7206c-79ad-44b7-bb48-42290dfce475" />


<img width="362" height="238" alt="image" src="https://github.com/user-attachments/assets/824272d3-282d-4743-9a2a-8c7bd2134e8f" />
