### PR TITLE
Add VW e-Golf (VWEG) to climate control capability checks

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui/CarFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui/CarFragment.kt
@@ -134,13 +134,14 @@ class CarFragment : BaseFragment(), View.OnClickListener, OnResultCommandListene
         val tabCarImageAC: ImageView = findViewById(R.id.tabCarImageAC) as ImageView
 
         // The V3 framework does not support capabilities yet, but
-        //	the Leaf, Smart, VW e-Up and Zoe Ph2 are the only cars providing command 26 up to now, so:
+        //	the Leaf, Smart, VW e-Up, VW e-Golf and Zoe Ph2 are the only cars providing command 26 up to now, so:
         if (carData.hasCommand(26)
             || carData.car_type == "NL"
             || carData.car_type == "SE"
             || carData.car_type == "SQ"
             || carData.car_type == "VWUP"
             || carData.car_type == "VWUP.T26"
+            || carData.car_type == "VWEG"
             || carData.car_type == "RZ2"
             || carData.car_type.startsWith("VA")
             || carData.car_type.startsWith("VB")

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/components/quickactions/ClimateQuickAction.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/components/quickactions/ClimateQuickAction.kt
@@ -68,7 +68,7 @@ class ClimateQuickAction(apiServiceGetter: () -> ApiService?, context: Context? 
 
     override fun commandsAvailable(): Boolean {
         return this.getCarData()?.hasCommand(26) == true
-                || getCarData()?.car_type in listOf("NL","SE","SQ","VWUP","VWUP.T26","RZ2")
+                || getCarData()?.car_type in listOf("NL","SE","SQ","VWUP","VWUP.T26","RZ2","VWEG")
                 || getCarData()?.car_type.orEmpty().startsWith("VA")
                 || getCarData()?.car_type.orEmpty().startsWith("VB")
                 || getCarData()?.car_type.orEmpty().startsWith("OAE")


### PR DESCRIPTION
The VW e-Golf vehicle module supports remote climate control (in latest edge firmware) via command 26, but the app's hardcoded car type lists did not include VWEG, so the A/C button and climate quick action were hidden.