### PR TITLE
Add VWEG cabin temperature display and model name

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui/CarFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui/CarFragment.kt
@@ -802,8 +802,9 @@ class CarFragment : BaseFragment(), View.OnClickListener, OnResultCommandListene
         // "Temp PEM" box:
         val pemtvl = findViewById(R.id.tabCarTextPEMLabel) as TextView
         val pemtv = findViewById(R.id.tabCarTextPEM) as TextView
-        // Display of cabin temperature for all vehicles that support it: VWUP VWUP.T26 NL KS KN VA MI SE SQ
+        // Display of cabin temperature for all vehicles that support it: VWUP VWUP.T26 VWEG NL KS KN VA MI SE SQ
         if (carData.car_type == "VWUP"
+            || carData.car_type == "VWEG"
             || carData.car_type == "KS"
             || carData.car_type == "KN"
             || carData.car_type.startsWith("VA")

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/HomeFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/HomeFragment.kt
@@ -1761,6 +1761,7 @@ class HomeFragment : BaseFragment(), OnResultCommandListener, HomeTabsAdapter.It
             "TS"              to "Tesla Model S",
             "TYR4"            to "Toyota RAV4 EV",
             "VA"              to "Chevrolet Volt/Ampera",
+            "VWEG"            to "VW e-Golf",
             "VWUP"            to "VW e-Up",
             "XX"              to "TRACK",
             "ZEVA"            to "ZEVA BMS",


### PR DESCRIPTION
The e-Golf module provides v.e.cabintemp, so show it in the classic UI's Temp PEM box, and map VWEG to "VW e-Golf" (the module's registered name) for the home screen model name display.