### PR TITLE
Fix drive mode display for VW e-Up and e-Golf

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/EnergyFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/EnergyFragment.kt
@@ -219,11 +219,20 @@ class EnergyFragment : BaseFragment(), OnResultCommandListener, EnergyMetricsAda
         if(carData?.car_type !in listOf("SQ")) {
             energyMetricsAdapter.mData += EnergyMetric(
                 getString(R.string.drive_mode),
-                when (carData?.car_drivemode) {
-                    0 -> getString(R.string.normal)
-                    1 -> getString(R.string.drive_mode_eco)
-                    else -> getString(R.string.unknown)
-                }
+                if (carData?.car_type in listOf("VWUP", "VWUP.T26", "VWEG"))
+                    // VW e-Up / e-Golf drive profiles: 1=Normal, 2=Eco, 3=Eco+
+                    when (carData?.car_drivemode) {
+                        1 -> getString(R.string.normal)
+                        2 -> getString(R.string.drive_mode_eco)
+                        3 -> getString(R.string.drive_mode_eco_plus)
+                        else -> getString(R.string.unknown)
+                    }
+                else
+                    when (carData?.car_drivemode) {
+                        0 -> getString(R.string.normal)
+                        1 -> getString(R.string.drive_mode_eco)
+                        else -> getString(R.string.unknown)
+                    }
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,6 +837,7 @@
     <string name="drive_mode">Drive Mode</string>
     <string name="normal">Normal</string>
     <string name="drive_mode_eco">ECO/B Mode</string>
+    <string name="drive_mode_eco_plus">Eco+</string>
     <string name="unknown">Unknown</string>
     <string name="temp">Temperature</string>
     <string name="lb_communications">Communications</string>


### PR DESCRIPTION
The VW modules encode v.e.drivemode as 1=Normal, 2=Eco, 3=Eco+, but the Energy page used the generic 0=Normal / 1=Eco mapping, so a VW driving in Normal showed "Eco" and the Eco/Eco+ modes showed "Unknown". Use the VW encoding for VWUP, VWUP.T26 and VWEG.