### PR TITLE
pressure values now in psi/bar/kPa, for smartEQ at control TPMS config improvement

### DIFF
--- a/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
@@ -501,10 +501,10 @@ class CarData : Serializable {
             car_tpms_rr_p = String.format("%.0f%s", car_tpms_rr_p_raw * 6.895, "kPa")
         } else {
             // default is psi ("off")
-            car_tpms_fl_p = String.format("%.1f%s", car_tpms_fl_p_raw, "psi")
-            car_tpms_fr_p = String.format("%.1f%s", car_tpms_fr_p_raw, "psi")
-            car_tpms_rl_p = String.format("%.1f%s", car_tpms_rl_p_raw, "psi")
-            car_tpms_rr_p = String.format("%.1f%s", car_tpms_rr_p_raw, "psi")
+            car_tpms_fl_p = String.format("%.0f%s", car_tpms_fl_p_raw, "psi")
+            car_tpms_fr_p = String.format("%.0f%s", car_tpms_fr_p_raw, "psi")
+            car_tpms_rl_p = String.format("%.0f%s", car_tpms_rl_p_raw, "psi")
+            car_tpms_rr_p = String.format("%.0f%s", car_tpms_rr_p_raw, "psi")
         }
         var sval: String
         var dval: Double
@@ -514,10 +514,10 @@ class CarData : Serializable {
                 sval = if (showTpmsBar == "on") {
                     String.format("%.1f%s", Math.floor(dval / 10) / 10, "bar")
                 } else if (showTpmsBar == "kpa") {
-                    String.format("%.0f%s", Math.floor(dval * 10) / 10, "kPa")
+                    String.format("%.0f%s", dval, "kPa")
                 } else {
                     // default is psi ("off")
-                    String.format("%.1f%s", Math.floor(dval * 1.450377) / 10, "psi")
+                    String.format("%.0f%s", Math.floor(dval * 1.450377) / 10, "psi")
                 }
 
                 car_tpms_pressure!![j] = sval

--- a/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/entities/CarData.kt
@@ -455,7 +455,6 @@ class CarData : Serializable {
      * Calculate derived variables including prefs dependencies
      */
     fun recalc() {
-        val showTpmsBar = appPrefs!!.getData("showtpmsbar") == "on"
         val showFahrenheit = appPrefs!!.getData("showfahrenheit") == "on"
         if (showFahrenheit) {
             car_temp_pem = String.format("%.1f\u00B0F", car_temp_pem_raw * (9.0 / 5.0) + 32.0)
@@ -467,26 +466,7 @@ class CarData : Serializable {
             car_temp_charger =
                 String.format("%.1f\u00B0F", car_temp_charger_raw * (9.0 / 5.0) + 32.0)
             car_temp_cabin = String.format("%.1f\u00B0F", car_temp_cabin_raw * (9.0 / 5.0) + 32.0)
-        } else {
-            car_temp_pem = String.format("%.1f\u00B0C", car_temp_pem_raw)
-            car_temp_motor = String.format("%.1f\u00B0C", car_temp_motor_raw)
-            car_temp_battery = String.format("%.1f\u00B0C", car_temp_battery_raw)
-            car_temp_ambient = String.format("%.1f\u00B0C", car_temp_ambient_raw)
-            car_temp_charger = String.format("%.1f\u00B0C", car_temp_charger_raw)
-            car_temp_cabin = String.format("%.1f\u00B0C", car_temp_cabin_raw)
-        }
-        if (showTpmsBar) {
-            car_tpms_fl_p = String.format("%.1f%s", car_tpms_fl_p_raw / 14.504, "bar")
-            car_tpms_fr_p = String.format("%.1f%s", car_tpms_fr_p_raw / 14.504, "bar")
-            car_tpms_rl_p = String.format("%.1f%s", car_tpms_rl_p_raw / 14.504, "bar")
-            car_tpms_rr_p = String.format("%.1f%s", car_tpms_rr_p_raw / 14.504, "bar")
-        } else {
-            car_tpms_fl_p = String.format("%.1f%s", car_tpms_fl_p_raw, "psi")
-            car_tpms_fr_p = String.format("%.1f%s", car_tpms_fr_p_raw, "psi")
-            car_tpms_rl_p = String.format("%.1f%s", car_tpms_rl_p_raw, "psi")
-            car_tpms_rr_p = String.format("%.1f%s", car_tpms_rr_p_raw, "psi")
-        }
-        if (showFahrenheit) {
+            // wheels
             car_tpms_fl_t =
                 String.format("%.0f%s", car_tpms_fl_t_raw * (9.0 / 5.0) + 32.0, "\u00B0F")
             car_tpms_fr_t =
@@ -496,21 +476,50 @@ class CarData : Serializable {
             car_tpms_rr_t =
                 String.format("%.0f%s", car_tpms_rr_t_raw * (9.0 / 5.0) + 32.0, "\u00B0F")
         } else {
+            car_temp_pem = String.format("%.1f\u00B0C", car_temp_pem_raw)
+            car_temp_motor = String.format("%.1f\u00B0C", car_temp_motor_raw)
+            car_temp_battery = String.format("%.1f\u00B0C", car_temp_battery_raw)
+            car_temp_ambient = String.format("%.1f\u00B0C", car_temp_ambient_raw)
+            car_temp_charger = String.format("%.1f\u00B0C", car_temp_charger_raw)
+            car_temp_cabin = String.format("%.1f\u00B0C", car_temp_cabin_raw)
+            // wheels
             car_tpms_fl_t = String.format("%.0f%s", car_tpms_fl_t_raw, "\u00B0C")
             car_tpms_fr_t = String.format("%.0f%s", car_tpms_fr_t_raw, "\u00B0C")
             car_tpms_rl_t = String.format("%.0f%s", car_tpms_rl_t_raw, "\u00B0C")
             car_tpms_rr_t = String.format("%.0f%s", car_tpms_rr_t_raw, "\u00B0C")
+        }
+        val showTpmsBar = appPrefs!!.getData("showtpmsbar")
+        if (showTpmsBar == "on") {
+            car_tpms_fl_p = String.format("%.1f%s", car_tpms_fl_p_raw / 14.504, "bar")
+            car_tpms_fr_p = String.format("%.1f%s", car_tpms_fr_p_raw / 14.504, "bar")
+            car_tpms_rl_p = String.format("%.1f%s", car_tpms_rl_p_raw / 14.504, "bar")
+            car_tpms_rr_p = String.format("%.1f%s", car_tpms_rr_p_raw / 14.504, "bar")
+        } else if (showTpmsBar == "kpa") {
+            car_tpms_fl_p = String.format("%.0f%s", car_tpms_fl_p_raw * 6.895, "kPa")
+            car_tpms_fr_p = String.format("%.0f%s", car_tpms_fr_p_raw * 6.895, "kPa")
+            car_tpms_rl_p = String.format("%.0f%s", car_tpms_rl_p_raw * 6.895, "kPa")
+            car_tpms_rr_p = String.format("%.0f%s", car_tpms_rr_p_raw * 6.895, "kPa")
+        } else {
+            // default is psi ("off")
+            car_tpms_fl_p = String.format("%.1f%s", car_tpms_fl_p_raw, "psi")
+            car_tpms_fr_p = String.format("%.1f%s", car_tpms_fr_p_raw, "psi")
+            car_tpms_rl_p = String.format("%.1f%s", car_tpms_rl_p_raw, "psi")
+            car_tpms_rr_p = String.format("%.1f%s", car_tpms_rr_p_raw, "psi")
         }
         var sval: String
         var dval: Double
         if (car_tpms_pressure_raw != null && car_tpms_pressure != null && car_tpms_pressure_raw!!.size == car_tpms_pressure!!.size) {
             for (j in car_tpms_pressure_raw!!.indices) {
                 dval = car_tpms_pressure_raw!![j]
-                sval = if (showTpmsBar) String.format(
-                    "%.1f%s",
-                    Math.floor(dval / 10) / 10,
-                    "bar"
-                ) else String.format("%.1f%s", Math.floor(dval * 1.450377) / 10, "psi")
+                sval = if (showTpmsBar == "on") {
+                    String.format("%.1f%s", Math.floor(dval / 10) / 10, "bar")
+                } else if (showTpmsBar == "kpa") {
+                    String.format("%.0f%s", Math.floor(dval * 10) / 10, "kPa")
+                } else {
+                    // default is psi ("off")
+                    String.format("%.1f%s", Math.floor(dval * 1.450377) / 10, "psi")
+                }
+
                 car_tpms_pressure!![j] = sval
             }
         }

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ChargingFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ChargingFragment.kt
@@ -476,8 +476,19 @@ class ChargingFragment : BaseFragment(), OnResultCommandListener {
             }
 
             override fun onStopTrackingTouch(slider: RangeSlider) {
+                val title = if (carData?.car_type == "SQ") {
+                    getString(R.string.lb_charger_confirm_soc_change, ampLimit.text.toString())
+                } else {
+                    getString(chargeLimitActionTitle)
+                }
+                val msg = if (carData?.car_type == "SQ") {
+                    R.string.lb_charger_sq_no_stop_hint
+                } else {
+                    R.string.blankspace
+                }
                 MaterialAlertDialogBuilder(requireActivity())
-                    .setTitle(chargeLimitActionTitle)
+                    .setTitle(title)
+                    .setMessage(msg)
                     .setNegativeButton(R.string.Cancel) {_, _ ->}
                     .setPositiveButton(android.R.string.ok, fun(dlg: DialogInterface, which: Int) {
                         if (carData?.car_type == "RT") {

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ControlsFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ControlsFragment.kt
@@ -280,7 +280,7 @@ class ControlsFragment : BaseFragment(), OnResultCommandListener {
         val kpa = kpaStr?.toDoubleOrNull() ?: 0.0
         return when (getPressureUnit()) {
             "on" -> String.format(Locale.US, "%.2f", kpa / 100.0)
-            "off" -> String.format(Locale.US, "%.1f", kpa * 0.145038)
+            "off" -> String.format(Locale.US, "%.0f", kpa * 0.145038)
             else -> kpa.roundToInt().toString()
         }
     }

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ControlsFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/ControlsFragment.kt
@@ -27,6 +27,7 @@ import com.google.android.material.floatingactionbutton.ExtendedFloatingActionBu
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.openvehicles.OVMS.R
 import com.openvehicles.OVMS.api.CommandActivity
 import com.openvehicles.OVMS.api.OnResultCommandListener
@@ -54,6 +55,8 @@ import com.openvehicles.OVMS.utils.CarsStorage
 import com.openvehicles.OVMS.utils.CarsStorage.getLastSelectedCarId
 import java.text.DateFormat
 import java.util.Date
+import java.util.Locale
+import kotlin.math.roundToInt
 
 
 class ControlsFragment : BaseFragment(), OnResultCommandListener {
@@ -209,14 +212,20 @@ class ControlsFragment : BaseFragment(), OnResultCommandListener {
         body.visibility = if (isExpanded) View.VISIBLE else View.GONE
         chevron.rotation = if (isExpanded) 90f else 0f
         
+        val unitLabel = when (getPressureUnit()) {
+            "on" -> "bar"
+            "off" -> "psi"
+            else -> "kPa"
+        }
+
         val alert = tpmsConfig["tpms.alert.enable"] ?: "no"
-        val front = tpmsConfig["tpms.front.pressure"] ?: "0"
-        val rear = tpmsConfig["tpms.rear.pressure"] ?: "0"
+        val front = convertKpaToDisplay(tpmsConfig["tpms.front.pressure"])
+        val rear = convertKpaToDisplay(tpmsConfig["tpms.rear.pressure"])
         val temp = tpmsConfig["tpms.temp"] ?: "no"
-        val warnVal = tpmsConfig["tpms.value.warn"] ?: "0"
-        val alertVal = tpmsConfig["tpms.value.alert"] ?: "0"
+        val warnVal = convertKpaToDisplay(tpmsConfig["tpms.value.warn"])
+        val alertVal = convertKpaToDisplay(tpmsConfig["tpms.value.alert"])
         
-        summaryView.text = "\nAlert message: $alert \n\nShow temperatures: $temp \n\nTarget pressure:\n  Front: $front kPa • Rear: $rear kPa \n\nDifference from target pressure:\n  Warn: $warnVal kPa • Alert: $alertVal kPa"
+        summaryView.text = "\nAlert message: $alert \n\nShow temperatures: $temp \n\nTarget pressure:\n  Front: $front $unitLabel • Rear: $rear $unitLabel \n\nDifference from target pressure:\n  Warn: $warnVal $unitLabel • Alert: $alertVal $unitLabel"
     }
 
     private fun showEditTPMSConfigDialog() {
@@ -228,12 +237,24 @@ class ControlsFragment : BaseFragment(), OnResultCommandListener {
         val etWarn = dialogView.findViewById<TextInputEditText>(R.id.etWarnValue)
         val etAlert = dialogView.findViewById<TextInputEditText>(R.id.etAlertValue)
 
+        val unitLabel = when (getPressureUnit()) {
+            "on" -> "bar"
+            "off" -> "psi"
+            else -> "kPa"
+        }
+        
+        // Update hints to show current unit
+        dialogView.findViewById<TextInputLayout>(R.id.tilFrontPressure)?.hint = "Front Target ($unitLabel)"
+        dialogView.findViewById<TextInputLayout>(R.id.tilRearPressure)?.hint = "Rear Target ($unitLabel)"
+        dialogView.findViewById<TextInputLayout>(R.id.tilWarnValue)?.hint = "Warning Delta ($unitLabel)"
+        dialogView.findViewById<TextInputLayout>(R.id.tilAlertValue)?.hint = "Alert Delta ($unitLabel)"
+
         swAlert.isChecked = tpmsConfig["tpms.alert.enable"] == "yes"
-        etFront.setText(tpmsConfig["tpms.front.pressure"] ?: "0")
-        etRear.setText(tpmsConfig["tpms.rear.pressure"] ?: "0")
+        etFront.setText(convertKpaToDisplay(tpmsConfig["tpms.front.pressure"]))
+        etRear.setText(convertKpaToDisplay(tpmsConfig["tpms.rear.pressure"]))
         swTemp.isChecked = tpmsConfig["tpms.temp"] == "yes"
-        etWarn.setText(tpmsConfig["tpms.value.warn"] ?: "0")
-        etAlert.setText(tpmsConfig["tpms.value.alert"] ?: "0")
+        etWarn.setText(convertKpaToDisplay(tpmsConfig["tpms.value.warn"]))
+        etAlert.setText(convertKpaToDisplay(tpmsConfig["tpms.value.alert"]))
 
         MaterialAlertDialogBuilder(requireContext())
             .setTitle("TPMS Config (XSQ)")
@@ -241,16 +262,37 @@ class ControlsFragment : BaseFragment(), OnResultCommandListener {
             .setPositiveButton(R.string.Save) { _, _ ->
                 val newConfig = mapOf(
                     "tpms.alert.enable" to if (swAlert.isChecked) "yes" else "no",
-                    "tpms.front.pressure" to etFront.text.toString(),
-                    "tpms.rear.pressure" to etRear.text.toString(),
+                    "tpms.front.pressure" to convertDisplayToKpa(etFront.text.toString()),
+                    "tpms.rear.pressure" to convertDisplayToKpa(etRear.text.toString()),
                     "tpms.temp" to if (swTemp.isChecked) "yes" else "no",
-                    "tpms.value.warn" to etWarn.text.toString(),
-                    "tpms.value.alert" to etAlert.text.toString()
+                    "tpms.value.warn" to convertDisplayToKpa(etWarn.text.toString()),
+                    "tpms.value.alert" to convertDisplayToKpa(etAlert.text.toString())
                 )
                 saveTPMSConfig(newConfig)
             }
             .setNegativeButton(R.string.Cancel, null)
             .show()
+    }
+
+    private fun getPressureUnit(): String = appPrefs.getData("showtpmsbar", "off") ?: "off"
+
+    private fun convertKpaToDisplay(kpaStr: String?): String {
+        val kpa = kpaStr?.toDoubleOrNull() ?: 0.0
+        return when (getPressureUnit()) {
+            "on" -> String.format(Locale.US, "%.2f", kpa / 100.0)
+            "off" -> String.format(Locale.US, "%.1f", kpa * 0.145038)
+            else -> kpa.roundToInt().toString()
+        }
+    }
+
+    private fun convertDisplayToKpa(displayStr: String): String {
+        val value = displayStr.replace(",", ".").toDoubleOrNull() ?: 0.0
+        val kpa = when (getPressureUnit()) {
+            "on" -> value * 100.0
+            "off" -> value / 0.145038
+            else -> value
+        }
+        return kpa.roundToInt().toString()
     }
 
     private fun saveTPMSConfig(newConfig: Map<String, String>) {

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/HomeFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/HomeFragment.kt
@@ -802,7 +802,6 @@ class HomeFragment : BaseFragment(), OnResultCommandListener, HomeTabsAdapter.It
                 }
 
                 var chargeStateInfo = 0
-
                 when (carData!!.car_charge_state_i_raw) {
                     2 -> chargeStateInfo = R.string.state_topping_off_label
                     4 -> chargeStateInfo = R.string.state_done_label
@@ -1214,8 +1213,19 @@ class HomeFragment : BaseFragment(), OnResultCommandListener, HomeTabsAdapter.It
             }
 
             override fun onStopTrackingTouch(slider: RangeSlider) {
+                val title = if (carData?.car_type == "SQ") {
+                    getString(R.string.lb_charger_confirm_soc_change, ampLimit.text.toString())
+                } else {
+                    getString(chargeLimitActionTitle)
+                }
+                val msg = if (carData?.car_type == "SQ") {
+                    R.string.lb_charger_sq_no_stop_hint
+                } else {
+                    R.string.blankspace
+                }
                 MaterialAlertDialogBuilder(requireActivity())
-                    .setTitle(chargeLimitActionTitle)
+                    .setTitle(title)
+                    .setMessage(msg)
                     .setNegativeButton(R.string.Cancel) {_, _ ->}
                     .setPositiveButton(android.R.string.ok, fun(dlg: DialogInterface, which: Int) {
                         if (carData?.car_type == "RT") {

--- a/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/AppUISettingsFragment.kt
+++ b/app/src/main/java/com/openvehicles/OVMS/ui2/pages/settings/AppUISettingsFragment.kt
@@ -123,11 +123,11 @@ class AppUISettingsFragment: PreferenceFragmentCompat() {
         // TPMS setting
 
         val vehicleId = getLastSelectedCarId()
-        val pressurePreference = findPreference<SwitchPreferenceCompat>("pressure_psi_bar")
-        pressurePreference?.isChecked = appPrefs.getData("showtpmsbar", "off") == "on"
+        val pressurePreference = findPreference<ListPreference>("pressure_psi_bar")
+        pressurePreference?.value = appPrefs.getData("showtpmsbar", "off")
         pressurePreference?.onPreferenceChangeListener =
             OnPreferenceChangeListener { preference, newValue ->
-                appPrefs.saveData("showtpmsbar", if (newValue as Boolean) "on" else "off")
+                appPrefs.saveData("showtpmsbar", newValue as String)
                 true
             }
 
@@ -150,10 +150,10 @@ class AppUISettingsFragment: PreferenceFragmentCompat() {
         // TODO: option only for supported Cars visible or enable?
         // tpmsSortByFirmwarePreference?.isVisible = carData?.car_type in listOf("SQ")
         tpmsSortByFirmwarePreference?.isEnabled = carData?.car_type !in listOf("RT", "EN", "NRJK", "SQ")
-        tpmsSortByFirmwarePreference?.isChecked = appPrefs.getData("tmps_firmware_$vehicleId", "off") == "on"
+        tpmsSortByFirmwarePreference?.isChecked = appPrefs.getData("tpms_firmware_$vehicleId", "off") == "on"
         tpmsSortByFirmwarePreference?.onPreferenceChangeListener =
             OnPreferenceChangeListener { preference, newValue ->
-                appPrefs.saveData("tmps_firmware_$vehicleId",if (newValue as Boolean) "on" else "off")
+                appPrefs.saveData("tpms_firmware_$vehicleId",if (newValue as Boolean) "on" else "off")
                 appPrefs.saveData("tpms_fl_$vehicleId", "0")
                 appPrefs.saveData("tpms_fr_$vehicleId", "1")
                 appPrefs.saveData("tpms_rl_$vehicleId", "2")

--- a/app/src/main/res/layout/dialog_edit_tpms_config.xml
+++ b/app/src/main/res/layout/dialog_edit_tpms_config.xml
@@ -17,27 +17,29 @@
             android:layout_marginBottom="16dp"/>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilFrontPressure"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Front target pressure (kPa)"
+            android:hint="Front target pressure"
             android:layout_marginBottom="16dp">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etFrontPressure"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilRearPressure"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Rear target pressure (kPa)"
+            android:hint="Rear target pressure"
             android:layout_marginBottom="16dp">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etRearPressure"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.materialswitch.MaterialSwitch
@@ -48,27 +50,29 @@
             android:layout_marginBottom="16dp"/>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilWarnValue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Warning at difference (kPa)"
+            android:hint="Warning at difference"
             android:layout_marginBottom="16dp">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etWarnValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilAlertValue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Alert at difference (kPa)"
+            android:hint="Alert at difference"
             android:layout_marginBottom="16dp">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etAlertValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
@@ -76,7 +80,7 @@
             android:layout_width="359dp"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:text="bar * 100 = kPa \n2,5 bar = 250 kPa\nNew values ​​only take effect upon the update of the TPMS value."
+            android:text="New values ​​only take effect upon the update of the TPMS value."
             android:textStyle="bold" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_controls.xml
+++ b/app/src/main/res/layout/fragment_controls.xml
@@ -225,6 +225,7 @@
                 android:gravity="center"
                 android:padding="12dp"
                 android:text="TextView"
+                android:textSize="13sp"
                 android:textColor="@color/colorText"
                 android:textStyle="bold" />
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -307,7 +307,17 @@
     <string name="mi_map_settings">Einstellungen</string>
     
     <string name="mi_car_details_temp">Fahrenheit</string>
-    <string name="mi_car_details_tpms">TPMS in bar</string>
+    <string name="mi_car_details_tpms">Reifendruck-Einheit</string>
+    <string-array name="tpms_unit_labels">
+        <item>bar</item>
+        <item>psi</item>
+        <item>kPa</item>
+    </string-array>
+    <string-array name="tpms_unit_values" translatable="false">
+        <item>on</item>
+        <item>off</item>
+        <item>kpa</item>
+    </string-array>
 
     <string name="ocm_title_charge_points">LADESTATIONEN</string>
     <string name="ocm_subtitle_charge_points">Quelle: https://openchargemap.org/</string>
@@ -819,7 +829,8 @@
     <string name="lb_booster_day_end">letzter Tag</string>
     <string name="chargingpower">Ladeleistung</string>
     <string name="chargingeff">Effizienz</string>
-    <string name="lb_charger_confirm_soc_change">SoC limit setzen?</string>
+    <string name="lb_charger_confirm_soc_change">Benachrichtigung bei SoC %s?</string>
+    <string name="lb_charger_sq_no_stop_hint">Beim smart kann der Ladevorgang nicht per App gestoppt werden!</string>
     <string name="action_set_tab_color">Tab-Farbe festlegen</string>
     <string name="action_reset_tab_color">Tab-Farbe zurücksetzen</string>
     <string name="dialog_choose_color">Farbe auswählen</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,5 +2,6 @@
 <resources>
     <color name="colorBackground">#000000</color>
     <color name="colorText">#ffffff</color>
+    <color name="colorTextError">#FF4444</color>
     <color name="colorSurfaceContainer">#1E1E1E</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="blankspace"> </string>
     <string name="app_name">Open Vehicle</string>
     <string name="Loading">Please wait</string>
     <string name="Settings">Settings</string>
@@ -353,7 +354,17 @@
     <string name="mi_map_search">Search Google for chargers</string>
 
     <string name="mi_car_details_temp">Fahrenheit</string>
-    <string name="mi_car_details_tpms">TPMS in bar</string>
+    <string name="mi_car_details_tpms">TPMS unit</string>
+    <string-array name="tpms_unit_labels">
+        <item>bar</item>
+        <item>psi</item>
+        <item>kPa</item>
+    </string-array>
+    <string-array name="tpms_unit_values" translatable="false">
+        <item>on</item>
+        <item>off</item>
+        <item>kpa</item>
+    </string-array>
 
     <string name="cargroup_title">Car groups</string>
     <string name="cargroup_name_hint">Group name</string>
@@ -902,7 +913,8 @@
     <string name="select_ddt4all_action">DDT4all option</string>
     <string name="chargingpower">Charging power</string>
     <string name="chargingeff">efficiency</string>
-    <string name="lb_charger_confirm_soc_change">Really change SoC limit?</string>
+    <string name="lb_charger_confirm_soc_change">Notify when SOC reaches %s?</string>
+    <string name="lb_charger_sq_no_stop_hint">On the smart, the charging process cannot be stopped via the app!</string>
     <string name="action_set_tab_color">Set tab color</string>
     <string name="action_reset_tab_color">Reset tab color</string>
     <string name="dialog_choose_color">Choose a color</string>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -77,12 +77,16 @@
             app:key="api_key" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/tpms_settings">
-        <SwitchPreferenceCompat
+        <ListPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:defaultValue="false"
+            android:defaultValue="off"
+            android:persistent="false"
             android:title="@string/mi_car_details_tpms"
-            app:key="pressure_psi_bar" />
+            app:entries="@array/tpms_unit_labels"
+            app:entryValues="@array/tpms_unit_values"
+            app:key="pressure_psi_bar"
+            app:useSimpleSummaryProvider="true" />
         <SwitchPreferenceCompat
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
You can now select between psi, bar, and kPa for the tire pressure in the settings.

Changes implemented for smart EQ only:
1.
Dynamic unit conversion:
Display: Values ​​in the summary and the edit dialog are now automatically converted from kPa (vehicle default) to the selected unit. Input: Upon saving, your inputs are automatically converted back to kPa before being sent to the vehicle firmware.

2.
Improved edit dialog:
Input field labels (hints) in the dialog now dynamically adjust to the selected unit (e.g., "Front Target (bar)" instead of a fixed "kPa"). Input fields now accept decimal numbers (important for bar values).

3.
Technical details:
Conversion factors: 1 bar = 100 kPa and 1 psi ≈ 6.895 kPa. The conversion handles regional differences in decimal separators (comma vs. dot) robustly. The control view now consistently displays the same units you have configured for live data in the global app settings.

4.
To clarify that charging cannot be stopped once the set SoC limit is reached for the smart EQ, a relevant explanatory note has been added to the slider.

